### PR TITLE
install find_package config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,14 @@ cmake_minimum_required(VERSION 3.30 FATAL_ERROR)
 # set(CMAKE_COLOR_DIAGNOSTICS ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD 26)
 
-project(rsl_util LANGUAGES CXX)
+project(rsl_util VERSION 0.1 LANGUAGES CXX)
+
+include(GNUInstallDirs)
 
 add_library(rsl_util INTERFACE)
-target_compile_options(rsl_util INTERFACE 
+add_library(rsl::util ALIAS rsl_util)
+target_compile_options(rsl_util INTERFACE
   "-stdlib=libc++"
   "-freflection"
   "-fannotation-attributes"
@@ -16,17 +18,47 @@ target_compile_options(rsl_util INTERFACE
   "-fexpansion-statements"
   "-Wno-c++26-extensions"
 )
-target_link_options(rsl_util INTERFACE "-fexperimental-library" "-stdlib=libc++" "-lc++abi")
-
-target_include_directories(rsl_util INTERFACE 
-    $<INSTALL_INTERFACE:include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
-
-install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/ DESTINATION include)
+target_compile_features(rsl_util INTERFACE cxx_std_26)
+target_link_options(rsl_util INTERFACE "-fexperimental-library" "-stdlib=libc++")
+target_link_libraries(rsl_util INTERFACE "c++abi")
+target_include_directories(rsl_util INTERFACE
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+)
 
 option(BUILD_TESTING "Enable tests" ON)
 option(ENABLE_COVERAGE "Enable coverage instrumentation" OFF)
 option(BUILD_EXAMPLES "Enable examples" ON)
+option(RSL_UTIL_INSTALL "Generate install target for rsl_util" ON)
+
+if (RSL_UTIL_INSTALL)
+  set(CMAKE_INSTALLDIR_CMAKEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/rsl-util)
+
+  set_target_properties(rsl_util PROPERTIES EXPORT_NAME util)
+  install(TARGETS rsl_util EXPORT rsl-util-targets)
+  install(EXPORT rsl-util-targets
+    NAMESPACE rsl::
+    DESTINATION ${CMAKE_INSTALLDIR_CMAKEDIR}
+  )
+
+  include(CMakePackageConfigHelpers)
+  configure_package_config_file(cmake/rsl-util-config.cmake.in
+    ${PROJECT_BINARY_DIR}/rsl-util-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALLDIR_CMAKEDIR}/rsl-util-config.cmake
+  )
+  write_basic_package_version_file(${PROJECT_BINARY_DIR}/rsl-util-config-version.cmake
+    COMPATIBILITY SameMajorVersion
+    ARCH_INDEPENDENT
+  )
+  install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+  install(FILES
+    ${PROJECT_BINARY_DIR}/rsl-util-config-version.cmake
+    ${PROJECT_BINARY_DIR}/rsl-util-config.cmake
+    DESTINATION ${CMAKE_INSTALLDIR_CMAKEDIR}
+  )
+endif()
 
 if (BUILD_TESTING)
   message(STATUS "Building unit tests")

--- a/cmake/rsl-util-config.cmake.in
+++ b/cmake/rsl-util-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+if (NOT TARGET rsl::util)
+  include(${CMAKE_CURRENT_LIST_DIR}/rsl-util-targets.cmake)
+endif()

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ class RslUtilRecipe(ConanFile):
     default_options = {"coverage": False, "examples": False}
     generators = "CMakeToolchain", "CMakeDeps"
 
-    exports_sources = "CMakeLists.txt", "include/*"
+    exports_sources = "CMakeLists.txt", "include/*", "test/*", "cmake/*"
 
     def requirements(self):
         self.test_requires("gtest/1.14.0")
@@ -43,8 +43,8 @@ class RslUtilRecipe(ConanFile):
             cmake.build()
 
     def package(self):
-        # TODO verify this works
-        copy(self, "include/rsl/*", self.source_folder, self.package_folder)
+        cmake = CMake(self)
+        cmake.install()
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "rsl-util")


### PR DESCRIPTION
Add `install()` steps to allow `find_package(rsl-util)` to work with the `cmake --install`ed library.

- changed `set(CMAKE_CXX_STANDARD 26)` to `target_compile_features(rsl_util INTERFACE cxx_std_26)` so that this requirement gets propagated across `find_package` usage.
- `write_basic_package_version_file(...)` adds support selecting particular versions like `find_package(rsl-util 1.2.3)`.  
  Could be left out until the library actually starts publishing releases and incrementing version numbers.
- The cmake-generated rsl-config.cmake (etc.) is also included in the conan package.  
  This shouldn't interfere with anything, but would allow someone not using the conan-CMakeDeps generator in their project to still use `find_package(rsl-config)`)
- added an alias target so that FetchContent and find_package users can both refer to `rsl::util`