### PR TITLE
[span] Add unit tests for last, first, size_bytes, front, back and at

### DIFF
--- a/include/rsl/span
+++ b/include/rsl/span
@@ -51,14 +51,15 @@ concept span_compatible_sentinel_for =
 class span_common {
 public:
   // [span.sub], subviews
-  template <typename T, std::size_t Count>
+  template <std::size_t Count, typename T>
   constexpr span<typename std::remove_cvref_t<T>::element_type, Count> first(this T&& self) {
-    return {std::forward<T>(self).data(), Count};
+    return span<typename std::remove_cvref_t<T>::element_type, Count>{std::forward<T>(self).data(),
+                                                                      Count};
   }
 
-  template <typename T, std::size_t Count>
+  template <std::size_t Count, typename T>
   constexpr span<typename std::remove_cvref_t<T>::element_type, Count> last(this T&& self) {
-    return {self.data() + self.size() - Count, Count};
+    return span<typename std::remove_cvref_t<T>::element_type, Count>{self.data() + self.size() - Count, Count};
   }
 
   template <typename T>
@@ -80,17 +81,17 @@ public:
       this T&& self,
       typename std::remove_cvref_t<T>::size_type offset,
       typename std::remove_cvref_t<T>::size_type count = dynamic_extent) {
-        if (count == dynamic_extent) {
-          return {self.data() + offset, self.size() - offset};
-        }
-        return {self.data() + offset, count};
-      }
+    if (count == dynamic_extent) {
+      return {self.data() + offset, self.size() - offset};
+    }
+    return {self.data() + offset, count};
+  }
 
   // [span.obs], observers
   template <typename T>
   [[nodiscard]] constexpr typename std::remove_cvref_t<T>::size_type size_bytes(
       this T&& self) noexcept {
-    return std::forward<T>(self).size() * sizeof(typename T::element_type);
+    return std::forward<T>(self).size() * sizeof(typename std::remove_cvref_t<T>::element_type);
   }
   template <typename T>
   [[nodiscard]] constexpr bool empty(this T&& self) noexcept {
@@ -252,7 +253,8 @@ public:
   [[nodiscard]] constexpr std::size_t size() const { return Extent; }
 
   template <typename T, std::size_t Offset, std::size_t Count = dynamic_extent>
-  constexpr span<element_type, Count != dynamic_extent ? Count : Extent - Offset> subspan() const noexcept {
+  constexpr span<element_type, Count != dynamic_extent ? Count : Extent - Offset> subspan()
+      const noexcept {
     return {data() + Offset, Count == dynamic_extent ? size() - Offset : Count};
   }
 

--- a/test/span/span.cpp
+++ b/test/span/span.cpp
@@ -70,3 +70,183 @@ TEST(span, Size) {
       rsl::span{define_static_array(members_of(^^::, std::meta::access_context::current()))};
   static_assert(spanOfInfo.size() > 1);
 }
+
+template <typename ReferenceT>
+constexpr void testSpanAt(auto&& anySpan, int index, auto expectedValue) {
+  // non-const
+  {
+    std::same_as<ReferenceT> decltype(auto) elem = anySpan.at(index);
+    ASSERT_EQ(elem, expectedValue);
+  }
+
+  // const
+  {
+    std::same_as<ReferenceT> decltype(auto) elem = std::as_const(anySpan).at(index);
+    ASSERT_EQ(elem, expectedValue);
+  }
+}
+
+TEST(span, at) {
+  // With static extent
+  {
+    std::array arr{0, 1, 2, 3, 4, 5, 9084};
+    rsl::span arrSpan{arr};
+
+    ASSERT_TRUE(std::dynamic_extent != arrSpan.extent);
+
+    using ReferenceT = typename decltype(arrSpan)::reference;
+
+    testSpanAt<ReferenceT>(arrSpan, 0, 0);
+    testSpanAt<ReferenceT>(arrSpan, 1, 1);
+    testSpanAt<ReferenceT>(arrSpan, 6, 9084);
+  }
+
+  // With dynamic extent
+  {
+    std::vector vec{0, 1, 2, 3, 4, 5, 9084};
+    rsl::span vecSpan{vec};
+
+    ASSERT_TRUE(std::dynamic_extent == vecSpan.extent);
+
+    using ReferenceT = typename decltype(vecSpan)::reference;
+
+    testSpanAt<ReferenceT>(vecSpan, 0, 0);
+    testSpanAt<ReferenceT>(vecSpan, 1, 1);
+    testSpanAt<ReferenceT>(vecSpan, 6, 9084);
+  }
+
+  {
+    constexpr auto spanOfInfo =
+        rsl::span{define_static_array(members_of(^^::, std::meta::access_context::current()))};
+    static_assert(spanOfInfo.at(1) == members_of(^^::, std::meta::access_context::current())[1]);
+    static_assert(spanOfInfo.at(2) != members_of(^^::, std::meta::access_context::current())[1]);
+    static_assert(spanOfInfo.at(2) == members_of(^^::, std::meta::access_context::current())[2]);
+  }
+}
+
+TEST(span, back) {
+  // With static extent
+  {
+    std::array arr{0, 1, 2, 3, 4, 5, 9084};
+    rsl::span arrSpan{arr};
+    ASSERT_EQ(arrSpan.back(), 9084);
+  }
+
+  // With dynamic extent
+  {
+    std::vector vec{0, 1, 2, 3, 4, 5, 9084};
+    rsl::span vecSpan{vec};
+    ASSERT_EQ(vecSpan.back(), 9084);
+  }
+
+  {
+    constexpr auto members =
+        define_static_array(members_of(^^::, std::meta::access_context::current()));
+    constexpr auto spanOfInfo = rsl::span{members};
+    static_assert(spanOfInfo.back() == members[members.size() - 1]);
+  }
+}
+
+TEST(span, front) {
+  // With static extent
+  {
+    std::array arr{0, 1, 2, 3, 4, 5, 9084};
+    rsl::span arrSpan{arr};
+    ASSERT_EQ(arrSpan.front(), 0);
+  }
+
+  // With dynamic extent
+  {
+    std::vector vec{0, 1, 2, 3, 4, 5, 9084};
+    rsl::span vecSpan{vec};
+    ASSERT_EQ(vecSpan.front(), 0);
+  }
+
+  {
+    constexpr auto members =
+        define_static_array(members_of(^^::, std::meta::access_context::current()));
+    constexpr auto spanOfInfo = rsl::span{members};
+    static_assert(spanOfInfo.front() == members[0]);
+  }
+}
+
+TEST(span, size_bytes) {
+  // With static extent
+  {
+    std::array arr{0, 1, 2, 3, 4, 5, 9084};
+    rsl::span arrSpan{arr};
+    ASSERT_EQ(arrSpan.size_bytes(), arr.size() * sizeof(int));
+  }
+
+  // With dynamic extent
+  {
+    std::vector vec{0, 1, 2, 3, 4, 5, 9084};
+    rsl::span vecSpan{vec};
+    ASSERT_EQ(vecSpan.size_bytes(), vecSpan.size() * sizeof(int));
+  }
+
+  {
+    constexpr auto members =
+        define_static_array(members_of(^^::, std::meta::access_context::current()));
+    constexpr auto spanOfInfo = rsl::span{members};
+    static_assert(spanOfInfo.size_bytes() == members.size() * sizeof(std::meta::info));
+  }
+}
+
+TEST(span, first) {
+  // With static extent
+  {
+    std::array arr{0, 1, 2, 3, 4, 5, 9084};
+    rsl::span arrSpan{arr};
+    const auto firstThree = arrSpan.first(3);
+    ASSERT_EQ(firstThree.size(), 3);
+    ASSERT_EQ(firstThree[1], 1);
+    ASSERT_EQ(arrSpan.first<2>().size(), 2);
+  }
+
+  // With dynamic extent
+  {
+    std::vector vec{0, 1, 2, 3, 4, 5, 9084};
+    rsl::span vecSpan{vec};
+    auto const firstThree = vecSpan.first(3);
+    ASSERT_EQ(firstThree.size(), 3);
+    ASSERT_EQ(firstThree[1], 1);
+    ASSERT_EQ(vecSpan.first<2>().size(), 2);
+  }
+
+  {
+    constexpr auto members =
+        define_static_array(members_of(^^::, std::meta::access_context::current()));
+    constexpr auto spanOfInfo = rsl::span{members};
+    static_assert(spanOfInfo.first<3>().size() == 3);
+  }
+}
+
+TEST(span, last) {
+  // With static extent
+  {
+    std::array arr{0, 1, 2, 3, 4, 5, 9084};
+    rsl::span arrSpan{arr};
+    auto lastThree = arrSpan.last(3);
+    ASSERT_EQ(lastThree.size(), 3);
+    ASSERT_EQ(lastThree[2], 9084);
+    ASSERT_EQ(arrSpan.last<2>().size(), 2);
+  }
+
+  // With dynamic extent
+  {
+    std::vector vec{0, 1, 2, 3, 4, 5, 9084};
+    rsl::span vecSpan{vec};
+    auto const lastThree = vecSpan.last(3);
+    ASSERT_EQ(lastThree.size(), 3);
+    ASSERT_EQ(lastThree[2], 9084);
+    ASSERT_EQ(vecSpan.last<2>().size(), 2);
+  }
+
+  {
+    constexpr auto members =
+        define_static_array(members_of(^^::, std::meta::access_context::current()));
+    constexpr auto spanOfInfo = rsl::span{members};
+    static_assert(spanOfInfo.last<3>().size() == 3);
+  }
+}


### PR DESCRIPTION
Refs https://github.com/rsl-org/util/issues/4 
adds more unit tests inspired by libc++ passes and fixes `first` and `last` implementation
the reason for the change is that we can not deduce the type of the span and provide only one template argument for the count of elements for `first` and `last` functions, if you know a better approach to resolve it would be great :)

Also some random changes from clang-format :(