### PR TITLE
[variant] Tests and implementation for `get` and `assign`

### DIFF
--- a/include/rsl/variant
+++ b/include/rsl/variant
@@ -730,7 +730,8 @@ constexpr decltype(auto) get(V&& variant_) {
 
 template <typename T, _variant_impl::has_get V>
 constexpr decltype(auto) get(V&& variant_) {
-  return rsl::get<T>(std::forward<V>(variant_));
+  constexpr static std::size_t index = variant_.alternatives.get_index_of(^^T);
+  return rsl::get<index>(std::forward<V>(variant_));
 }
 
 template <std::size_t Idx, typename Storage>

--- a/include/rsl/variant
+++ b/include/rsl/variant
@@ -410,6 +410,17 @@ public:
     return *this;
   }
 
+  // converting assignment
+  template <typename T>
+    requires(!std::same_as<std::remove_cvref_t<T>, variant_base> &&
+             !_variant_impl::is_in_place<std::remove_cvref_t<T>> &&
+             selected_index<T> != variant_npos)
+  constexpr variant_base& operator=(T&& obj) noexcept(
+      is_nothrow_constructible_type(alternatives.types[selected_index<T>], {^^T})) {
+    emplace<selected_index<T>>(std::forward<T>(obj));
+    return *this;
+  }
+
   constexpr ~variant_base()
     requires std::is_trivially_destructible_v<Storage>
   = default;
@@ -795,8 +806,9 @@ class variant
 
 public:
   using _variant_impl::variant_base<storage_type>::variant_base;
-  constexpr variant(variant const&)            = default;
-  constexpr variant(variant&&)                 = default;
+  constexpr variant(variant const&) = default;
+  constexpr variant(variant&&)      = default;
+  using _variant_impl::variant_base<storage_type>::variant_base::operator=;
   constexpr variant& operator=(variant const&) = default;
   constexpr variant& operator=(variant&&)      = default;
   constexpr ~variant()                         = default;

--- a/include/rsl/variant
+++ b/include/rsl/variant
@@ -259,7 +259,7 @@ protected:
     }
 
     template for (constexpr auto Idx : std::views::iota(0ZU, alternatives.count)) {
-      if constexpr (std::is_nothrow_move_constructible_v<typename [:alternatives.types[Idx]:]>) {
+      if constexpr (std::is_nothrow_move_constructible_v<typename[:alternatives.types[Idx]:]>) {
         return true;
       }
     }
@@ -330,7 +330,8 @@ public:
   // TODO rewrite selected_index
   template <typename T>
   constexpr static auto selected_index =
-      _variant_impl::selected_index<T, typename [:substitute(^^_impl::TypeList, alternatives.types):]>;
+      _variant_impl::selected_index<T,
+                                    typename[:substitute(^^_impl::TypeList, alternatives.types):]>;
 
   // converting constructor
   template <typename T>
@@ -375,7 +376,7 @@ public:
                                   std::initializer_list<U> init_list,
                                   Args&&... args)  //
       noexcept(std::is_nothrow_constructible_v<    //
-               typename [:alternatives.types[Idx]:], std::initializer_list<U>&, Args...>)
+               typename[:alternatives.types[Idx]:], std::initializer_list<U>&, Args...>)
       : discriminator(Idx) {
     // Primary constructor
 
@@ -414,9 +415,11 @@ public:
   template <typename T>
     requires(!std::same_as<std::remove_cvref_t<T>, variant_base> &&
              !_variant_impl::is_in_place<std::remove_cvref_t<T>> &&
+             std::assignable_from<typename[:alternatives.types[selected_index<T>]:]&, T> &&
              selected_index<T> != variant_npos)
   constexpr variant_base& operator=(T&& obj) noexcept(
-      is_nothrow_constructible_type(alternatives.types[selected_index<T>], {^^T})) {
+      is_nothrow_constructible_type(alternatives.types[selected_index<T>],
+                                    {std::meta::remove_cvref(^^T)})) {
     emplace<selected_index<T>>(std::forward<T>(obj));
     return *this;
   }
@@ -469,7 +472,8 @@ public:
   template <typename T, typename Self>
   constexpr decltype(auto) get(this Self&& self) {
     // TODO is remove_reference required here?
-    return std::forward<Self>(self).template get<alternatives.get_index_of(remove_reference(^^T))>();
+    return std::forward<Self>(self)
+        .template get<alternatives.get_index_of(remove_reference(^^T))>();
   }
 
   void swap(variant_base& other) {
@@ -741,7 +745,8 @@ constexpr decltype(auto) get(V&& variant_) {
 
 template <typename T, _variant_impl::has_get V>
 constexpr decltype(auto) get(V&& variant_) {
-  constexpr static std::size_t index = variant_.alternatives.get_index_of(^^T);
+  constexpr static std::size_t index =
+      variant_.alternatives.get_index_of(std::meta::remove_cvref(^^T));
   return rsl::get<index>(std::forward<V>(variant_));
 }
 
@@ -796,8 +801,7 @@ using Storage = [:make_storage<Ts...>():];
 }  // namespace _impl
 
 template <typename... Ts>
-class variant
-    : public _variant_impl::variant_base<_impl::Storage<Ts...>> {
+class variant : public _variant_impl::variant_base<_impl::Storage<Ts...>> {
   static_assert(sizeof...(Ts) > 0, "variant must contain at least one alternative");
   static_assert((!std::is_reference_v<Ts> && ...), "variant must not have reference alternatives");
   static_assert((!std::is_void_v<Ts> && ...), "variant must not have void alternatives");

--- a/test/variant/CMakeLists.txt
+++ b/test/variant/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(rsl-util-test PRIVATE
   special_members.cpp
   swap.cpp)
 
+add_subdirectory(variant.assign)
 add_subdirectory(variant.bad.access)
 add_subdirectory(variant.get)
 add_subdirectory(variant.helper)

--- a/test/variant/variant.assign/CMakeLists.txt
+++ b/test/variant/variant.assign/CMakeLists.txt
@@ -1,0 +1,3 @@
+target_sources(rsl-util-test PRIVATE
+  assign.cpp
+)

--- a/test/variant/variant.assign/assign.cpp
+++ b/test/variant/variant.assign/assign.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+#include <rsl/variant>
+#include <rsl/string_view>
+
+#include <common/assertions.h>
+
+TEST(Assign, NonConverting) {
+  {
+    rsl::variant<int, float> v(43);
+    v = 42;
+    ASSERT_EQ(v.index(), 0);
+    ASSERT_EQ(rsl::get<0>(v), 42);
+  }
+  {
+    rsl::variant<int, float> v(4.3f);
+    ASSERT_EQ(v.index(), 1);
+    ASSERT_EQ(rsl::get<1>(v), 4.3f);
+    v = 42;
+    ASSERT_EQ(v.index(), 0);
+    ASSERT_EQ(rsl::get<0>(v), 42);
+  }
+  {
+    rsl::variant<unsigned, long> v;
+    v = 42;
+    ASSERT_EQ(v.index(), 1);
+    ASSERT_EQ(rsl::get<1>(v), 42);
+    v = 43u;
+    ASSERT_EQ(v.index(), 0);
+    ASSERT_EQ(rsl::get<0>(v), 43);
+  }
+  {
+    rsl::variant<rsl::string_view, int> v(3);
+    v = "bar";
+    assert(v.index() == 0);
+    assert(rsl::get<0>(v) == "bar");
+  }
+}

--- a/test/variant/variant.assign/assign.cpp
+++ b/test/variant/variant.assign/assign.cpp
@@ -4,12 +4,33 @@
 
 #include <common/assertions.h>
 
+const rsl::string_view& get_const_ref_string_view() {
+  static rsl::string_view sv("foo");
+  return sv;
+}
+
 TEST(Assign, NonConverting) {
   {
     rsl::variant<int, float> v(43);
     v = 42;
     ASSERT_EQ(v.index(), 0);
+    ASSERT_SAME(decltype(rsl::get<0>(v)), int&);
     ASSERT_EQ(rsl::get<0>(v), 42);
+  }
+  {
+    rsl::variant<int, float> v(43);
+    const int i = 42;
+    v           = i;
+    ASSERT_EQ(v.index(), 0);
+    ASSERT_SAME(decltype(rsl::get<0>(v)), int&);
+    ASSERT_EQ(rsl::get<0>(v), 42);
+  }
+  {
+    rsl::variant<rsl::string_view, float> v(43.0f);
+    v = get_const_ref_string_view();
+    ASSERT_SAME(decltype(rsl::get<0>(v)), rsl::string_view&);
+    ASSERT_EQ(v.index(), 0);
+    ASSERT_EQ(rsl::get<0>(v), rsl::string_view{"foo"});
   }
   {
     rsl::variant<int, float> v(4.3f);

--- a/test/variant/variant.get/CMakeLists.txt
+++ b/test/variant/variant.get/CMakeLists.txt
@@ -1,3 +1,4 @@
 target_sources(rsl-util-test PRIVATE 
   holds_alternative.cpp
+  get.cpp
 )

--- a/test/variant/variant.get/get.cpp
+++ b/test/variant/variant.get/get.cpp
@@ -3,44 +3,159 @@
 
 #include <common/assertions.h>
 
-TEST(Get, IndexLvalue){
-  using variant = rsl::variant<const int, float>;
-
+TEST(Get, IndexLvalue) {
+  using variant = rsl::variant<int, long>;
   {
     constexpr variant obj(42);
     ASSERT_NOT_NOEXCEPT(rsl::get<0>(obj));
     ASSERT_SAME(decltype(rsl::get<0>(obj)), const int&);
     static_assert(rsl::get<0>(obj) == 42, "Value mismatch");
   }
+  {
+    variant v(42l);
+    ASSERT_SAME(decltype(rsl::get<1>(v)), long&);
+    ASSERT_EQ(rsl::get<1>(v), 42l);
+  }
 }
-TEST(Get, IndexRvalue){
+TEST(Get, IndexRvalue) {
+  using variant = rsl::variant<int, long>;
+  {
+    variant v(42);
+    ASSERT_NOT_NOEXCEPT(rsl::get<0>(std::move(v)));
+    ASSERT_SAME(decltype(rsl::get<0>(std::move(v))), int&&);
+    ASSERT_EQ(rsl::get<0>(std::move(v)), 42);
+  }
+  {
+    variant v(42l);
+    ASSERT_SAME(decltype(rsl::get<1>(std::move(v))), long&&);
+    ASSERT_EQ(rsl::get<1>(std::move(v)), 42l);
+  }
+}
+
+TEST(Get, IndexConstLvalue) {
+  using variant = rsl::variant<int, long>;
+  {
+    constexpr variant v(42);
+    ASSERT_NOT_NOEXCEPT(rsl::get<0>(v));
+    ASSERT_SAME(decltype(rsl::get<0>(v)), const int&);
+    static_assert(rsl::get<0>(v) == 42, "");
+  }
+  {
+    const variant v(42);
+    ASSERT_NOT_NOEXCEPT(rsl::get<0>(v));
+    ASSERT_SAME(decltype(rsl::get<0>(v)), const int&);
+    ASSERT_EQ(rsl::get<0>(v), 42);
+  }
+  {
+    constexpr variant v(42l);
+    ASSERT_NOT_NOEXCEPT(rsl::get<1>(v));
+    ASSERT_SAME(decltype(rsl::get<1>(v)), const long&);
+    static_assert(rsl::get<1>(v) == 42, "");
+  }
+  {
+    const variant v(42l);
+    ASSERT_NOT_NOEXCEPT(rsl::get<1>(v));
+    ASSERT_SAME(decltype(rsl::get<1>(v)), const long&);
+    ASSERT_EQ(rsl::get<1>(v), 42);
+  }
+}
+
+TEST(Get, IndexConstRvalue) {
+  using variant = rsl::variant<int, long>;
+  {
+    const variant v(42);
+    ASSERT_NOT_NOEXCEPT(rsl::get<0>(std::move(v)));
+    ASSERT_SAME(decltype(rsl::get<0>(std::move(v))), const int&&);
+    assert(rsl::get<0>(std::move(v)) == 42);
+  }
+  {
+    const variant v(42l);
+    ASSERT_SAME(decltype(rsl::get<1>(std::move(v))), const long&&);
+    assert(rsl::get<1>(std::move(v)) == 42);
+  }
+}
+
+TEST(Get, IndexException) {
   // TODO
 }
 
-TEST(Get, IndexConstLvalue){
-  // TODO
+TEST(Get, TypeLvalue) {
+  using variant = rsl::variant<int, long>;
+  static_assert(std::same_as<rsl::variant_alternative<0, variant>::type, int>);
+  static_assert(std::same_as<rsl::variant_alternative<1, variant>::type, long>);
+  static_assert(
+      rsl::_variant_impl::variant_base<rsl::_impl::Storage<int, long>>::alternatives.get_index_of(
+          ^^int) == 0);
+  static_assert(
+      rsl::_variant_impl::variant_base<rsl::_impl::Storage<int, long>>::alternatives.get_index_of(
+          ^^long) == 1);
+  {
+    variant v(42);
+    ASSERT_NOT_NOEXCEPT(rsl::get<int>(v));
+    ASSERT_SAME(decltype(rsl::get<int>(v)), int&);
+    ASSERT_EQ(rsl::get<int>(v), 42);
+  }
+  {
+    variant v(42l);
+    ASSERT_SAME(decltype(rsl::get<long>(v)), long&);
+    ASSERT_EQ(rsl::get<long>(v), 42);
+  }
 }
 
-TEST(Get, IndexConstRvalue){
-  // TODO
+TEST(Get, TypeRvalue) {
+  using variant = rsl::variant<int, long>;
+  {
+    variant v(42);
+    ASSERT_NOT_NOEXCEPT(rsl::get<int>(std::move(v)));
+    ASSERT_SAME(decltype(rsl::get<int>(std::move(v))), int&&);
+    ASSERT_EQ(rsl::get<int>(std::move(v)), 42);
+  }
+  {
+    variant v(42l);
+    ASSERT_SAME(decltype(rsl::get<long>(std::move(v))), long&&);
+    ASSERT_EQ(rsl::get<long>(std::move(v)), 42);
+  }
 }
 
-TEST(Get, IndexException){
-  // TODO
+TEST(Get, TypeConstLvalue) {
+  using variant = rsl::variant<int, long>;
+  {
+    const variant v(42);
+    ASSERT_NOT_NOEXCEPT(rsl::get<int>(std::move(v)));
+    ASSERT_SAME(decltype(rsl::get<int>(std::move(v))), const int&&);
+    ASSERT_EQ(rsl::get<int>(std::move(v)), 42);
+  }
+  {
+    const variant v(42l);
+    ASSERT_SAME(decltype(rsl::get<long>(std::move(v))), const long&&);
+    ASSERT_EQ(rsl::get<long>(std::move(v)), 42);
+  }
 }
 
-TEST(Get, TypeLvalue){
-  // TODO
-}
-
-TEST(Get, TypeRvalue){
-  // TODO
-}
-
-TEST(Get, TypeConstLvalue){
-  // TODO
-}
-
-TEST(Get, TypeConstRvalue){
-  // TODO
+TEST(Get, TypeConstRvalue) {
+  using variant = rsl::variant<int, long>;
+  {
+    constexpr variant v(42);
+    ASSERT_NOT_NOEXCEPT(rsl::get<int>(v));
+    ASSERT_SAME(decltype(rsl::get<int>(v)), const int&);
+    static_assert(rsl::get<int>(v) == 42, "");
+  }
+  {
+    const variant v(42);
+    ASSERT_NOT_NOEXCEPT(rsl::get<int>(v));
+    ASSERT_SAME(decltype(rsl::get<int>(v)), const int&);
+    ASSERT_EQ(rsl::get<int>(v), 42);
+  }
+  {
+    constexpr variant v(42l);
+    ASSERT_NOT_NOEXCEPT(rsl::get<long>(v));
+    ASSERT_SAME(decltype(rsl::get<long>(v)), const long&);
+    static_assert(rsl::get<long>(v) == 42, "");
+  }
+  {
+    const variant v(42l);
+    ASSERT_NOT_NOEXCEPT(rsl::get<long>(v));
+    ASSERT_SAME(decltype(rsl::get<long>(v)), const long&);
+    ASSERT_EQ(rsl::get<long>(v), 42);
+  }
 }

--- a/test/variant/variant.get/get.cpp
+++ b/test/variant/variant.get/get.cpp
@@ -93,12 +93,20 @@ TEST(Get, TypeLvalue) {
     variant v(42);
     ASSERT_NOT_NOEXCEPT(rsl::get<int>(v));
     ASSERT_SAME(decltype(rsl::get<int>(v)), int&);
+    ASSERT_SAME(decltype(rsl::get<int&>(v)), int&);
+    ASSERT_SAME(decltype(rsl::get<const int&>(v)), int&);
+    ASSERT_SAME(decltype(rsl::get<int&&>(v)), int&);
     ASSERT_EQ(rsl::get<int>(v), 42);
+    ASSERT_EQ(rsl::get<int&>(v), 42);
+    ASSERT_EQ(rsl::get<const int&>(v), 42);
+    ASSERT_EQ(rsl::get<int&&>(v), 42);
   }
   {
     variant v(42l);
     ASSERT_SAME(decltype(rsl::get<long>(v)), long&);
+    ASSERT_SAME(decltype(rsl::get<const long&>(v)), long&);
     ASSERT_EQ(rsl::get<long>(v), 42);
+    ASSERT_EQ(rsl::get<const long&>(v), 42);
   }
 }
 
@@ -108,7 +116,11 @@ TEST(Get, TypeRvalue) {
     variant v(42);
     ASSERT_NOT_NOEXCEPT(rsl::get<int>(std::move(v)));
     ASSERT_SAME(decltype(rsl::get<int>(std::move(v))), int&&);
+    ASSERT_SAME(decltype(rsl::get<const int&>(std::move(v))), int&&);
+    ASSERT_SAME(decltype(rsl::get<int&&>(std::move(v))), int&&);
     ASSERT_EQ(rsl::get<int>(std::move(v)), 42);
+    ASSERT_EQ(rsl::get<const int&>(std::move(v)), 42);
+    ASSERT_EQ(rsl::get<int&&>(std::move(v)), 42);
   }
   {
     variant v(42l);
@@ -117,13 +129,17 @@ TEST(Get, TypeRvalue) {
   }
 }
 
-TEST(Get, TypeConstLvalue) {
+TEST(Get, TypeConstRvalue) {
   using variant = rsl::variant<int, long>;
   {
     const variant v(42);
     ASSERT_NOT_NOEXCEPT(rsl::get<int>(std::move(v)));
     ASSERT_SAME(decltype(rsl::get<int>(std::move(v))), const int&&);
+    ASSERT_SAME(decltype(rsl::get<const int&>(std::move(v))), const int&&);
+    ASSERT_SAME(decltype(rsl::get<const int&&>(std::move(v))), const int&&);
     ASSERT_EQ(rsl::get<int>(std::move(v)), 42);
+    ASSERT_EQ(rsl::get<const int&>(std::move(v)), 42);
+    ASSERT_EQ(rsl::get<const int&&>(std::move(v)), 42);
   }
   {
     const variant v(42l);
@@ -132,12 +148,15 @@ TEST(Get, TypeConstLvalue) {
   }
 }
 
-TEST(Get, TypeConstRvalue) {
+TEST(Get, TypeConstLvalue) {
   using variant = rsl::variant<int, long>;
   {
     constexpr variant v(42);
     ASSERT_NOT_NOEXCEPT(rsl::get<int>(v));
     ASSERT_SAME(decltype(rsl::get<int>(v)), const int&);
+    ASSERT_SAME(decltype(rsl::get<int&>(v)), const int&);
+    ASSERT_SAME(decltype(rsl::get<const int&>(v)), const int&);
+    ASSERT_SAME(decltype(rsl::get<int&&>(v)), const int&);
     static_assert(rsl::get<int>(v) == 42, "");
   }
   {


### PR DESCRIPTION
Closes https://github.com/rsl-org/util/issues/5 and adding some tests for `get` function
One important distinction is that the types for the variant should not be `const` not sure if this is desired though @Tsche 